### PR TITLE
Halcon13

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ There are two steps concerning building the Hirsch binding:
 
 This step parses the Halcon include files and generates python binding. It is run by doing:
 
-    python h-parse.py
+    python2 h-parse.py
     
-Note that you will need to edit h-parse.py to set the halcon include directory at the top of the files.
+You may need to edit src/find_halcon.py to set the halcon include directory at the top of the files.
 
 This distribution contains pregenerated bindings for halcon version 9, so this step may be skipped.
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ import distutils.ccompiler
 distutils.ccompiler.CCompiler.compile=parallelCCompile
 
 # Set to include and library directory of halcon
-HalconBaseDir = '/usr/local/halcon13'
-HalconIncludeDirs = [HalconBaseDir + '/include/halconcpp',
-                     HalconBaseDir + '/include']
+from src.find_halcon import HalconBaseDir
+HalconIncludeDirs = [HalconBaseDir + '/include/halconcpp/',
+                     HalconBaseDir + '/include/']
                      
 HalconLibraryDir = HalconBaseDir + '/lib/x64-linux'
 

--- a/src/find_halcon.py
+++ b/src/find_halcon.py
@@ -1,0 +1,15 @@
+import pathlib
+from pathlib import Path
+# Try to find HALCON 13
+HalconBaseDir = '/usr/local/halcon13'
+_possible_halcon_locations = ('/usr/local/halcon13/',
+                              '/opt/halcon13/',
+                              '/usr/local/halcon/',
+                              '/opt/halcon/',
+                              '/space/halcon13/')
+HalconIncludeDirectory = None
+for location in _possible_halcon_locations:
+    if Path(location).is_dir():
+        HalconBaseDir = location
+assert HalconBaseDir is not None, 'Could not find HALCON 13!'
+print 'Using HALCON from ', HalconIncludeDirectory

--- a/src/h-parse.py
+++ b/src/h-parse.py
@@ -12,11 +12,22 @@
 import sys
 import CppHeaderParser
 import re
-import glob 
+import glob
 import json
 import HParseTypes
+import pathlib
+from pathlib import Path
 
-HalconIncludeDirectory = '/space/halcon13/include/halconcpp/'
+# Try to find HALCON 13
+_possible_halcon_locations = ('/opt/halcon13/include/halconcpp/',
+                              '/opt/halcon/include/halconcpp/',
+                              '/space/halcon13/include/halconcpp/')
+HalconIncludeDirectory = None
+for location in _possible_halcon_locations:
+    if Path(location).is_dir():
+        HalconIncludeDirectory = location
+assert HalconIncludeDirectory is not None, 'Could not find HALCON 13!'
+print 'Using HALCON 13 from ', HalconIncludeDirectory
 
 headersToParse = ['HImage',
                   'HDataBase',
@@ -46,10 +57,10 @@ for headerType in headersToParse:
     except CppHeaderParser.CppParseError,  e:
         print e
         sys.exit(1)
-    
+
     for className,klass in cppHeader.classes.iteritems():
         if not className in HParseTypes.knownClasses:
-          continue
+            continue
         hClass = HParseTypes.PyHalconClass(className, headerStringList)
         myClasses[className] = (klass,hClass)
 
@@ -106,7 +117,7 @@ for className in myClasses.keys():
         hClass.addMethod(pm,doc)
 
     hClass.pruneRedundantMethods()
-    
+
     filename = '%s_autogen_methods_declarations.i'%className.lower()
     print 'Generating', filename
     with open(filename,'w') as fh:

--- a/src/h-parse.py
+++ b/src/h-parse.py
@@ -18,16 +18,8 @@ import HParseTypes
 import pathlib
 from pathlib import Path
 
-# Try to find HALCON 13
-_possible_halcon_locations = ('/opt/halcon13/include/halconcpp/',
-                              '/opt/halcon/include/halconcpp/',
-                              '/space/halcon13/include/halconcpp/')
-HalconIncludeDirectory = None
-for location in _possible_halcon_locations:
-    if Path(location).is_dir():
-        HalconIncludeDirectory = location
-assert HalconIncludeDirectory is not None, 'Could not find HALCON 13!'
-print 'Using HALCON 13 from ', HalconIncludeDirectory
+from find_halcon import HalconBaseDir
+HalconIncludeDirectory = HalconBaseDir + 'include/halconcpp/'
 
 headersToParse = ['HImage',
                   'HDataBase',


### PR DESCRIPTION
Look for halcon13 in a few different standard places, in addition to the non-standard places dov and I are using.

I confirmed that the bindings generate, install, and the toy examples work with python2 on Ubuntu 14.04.